### PR TITLE
Move accompaniment calendar viewing spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 
 coverage
 /logfile
+
+# Ignore IntelliJ stuff
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ NSC's programs include:
 
 More information:  http://www.newsanctuarynyc.org/
 
-## Getting setup
+## Setting up your Local Development Environment
 
 ### System Dependencies
 
@@ -166,11 +166,14 @@ The data is refeshed occassionally, but activities/accompaniments are likely to 
 
 ## Contributing
 1. Add a comment on your chosen Github issue to let other contributors know that you have 'claimed' it.
-2. Create a feature branch off master.
-3. Complete feature with tests!
-4. Check CircleCI to make sure tests are passing.
-5. Make a pull request and tag CZagrobelny to review.
-6. CZagrobelny will leave feedback and merge into master upon approval of the pull request.
+1. Fork the new_sanctuary_asylum repo and get it set up on your local development environment.
+1. Create a local feature branch off master.
+1. Complete the feature/fix the bug with passing tests!
+1. Push your feature branch back up to your fork of the repo.
+1. Make a new pull request between your branch and the original repo.
+1. Check CircleCI to make sure tests are passing.
+1. Tag CZagrobelny to review your pull request.
+1. CZagrobelny will leave feedback and merge into master upon approval of the pull request.
 
 ## Code of Conduct
 [Here](CODE_OF_CONDUCT.md)

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -188,11 +188,14 @@
 
         .confirmed {
           color: #229608;
-          margin-right: 4px;
           display: inline-block;
           overflow: visible;
           font-size: 16px;
           line-height: 10px;
+        }
+
+        .event-info-icon {
+          width: 15px;
         }
       }
       dd {

--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -5,7 +5,15 @@
   <h5><%= date.day %></h5>
   <dl>
   <% activities.each do |activity| %>
-      <dt><% if activity.confirmed? %><span class="confirmed">&#10003;</span><% end %><%= activity.occur_at.strftime("%I:%M %p") %></dt>
+      <dt>
+        <% if activity.confirmed? %>
+          <span class="confirmed">&#10003;</span>
+        <% end %>
+        <% if activity.accompaniment_leader_accompaniments.present? %>
+          <i class="fa fa-user" aria-hidden="true" title="Accompaniment leader attending"></i>
+        <% end %>
+        <%= activity.occur_at.strftime("%I:%M %p") %>
+      </dt>
       <dd>
         <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>"><%= "#{activity.event.humanize} for #{activity.friend.name}" %></a>
          <div id="modal_activity_<%= activity.id %>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">

--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -7,10 +7,10 @@
   <% activities.each do |activity| %>
       <dt>
         <% if activity.confirmed? %>
-          <span class="confirmed">&#10003;</span>
+          <span class="confirmed event-info-icon">&#10003;</span>
         <% end %>
         <% if activity.accompaniment_leader_accompaniments.present? %>
-          <i class="fa fa-user" aria-hidden="true" title="Accompaniment leader attending"></i>
+          <i class="fa fa-user event-info-icon" aria-hidden="true" title="Accompaniment leader attending"></i>
         <% end %>
         <%= activity.occur_at.strftime("%I:%M %p") %>
       </dt>

--- a/app/views/admin/friends/activities/_activity.html.erb
+++ b/app/views/admin/friends/activities/_activity.html.erb
@@ -29,7 +29,7 @@
       <% end %>
     <% end %>
     <strong>
-      <%= link_to 'Remove', community_admin_friend_activity_path(current_community.slug, friend, activity), method: :delete, :data => {:confirm => 'Are you sure you want to remove this activity?'}, remote: true, style: 'color: #b30000 !important; font-style: italic;' %>
+      <%= link_to 'Remove', community_admin_friend_activity_path(current_community.slug, friend, activity), method: :delete, data: { confirm: 'Are you sure you want to remove this activity?' }, remote: true, style: 'color: #b30000 !important; font-style: italic;' %>
     </strong>
   </div>
   <div class='col-md-3'>

--- a/app/views/admin/friends/activities/_activity.html.erb
+++ b/app/views/admin/friends/activities/_activity.html.erb
@@ -29,7 +29,7 @@
       <% end %>
     <% end %>
     <strong>
-      <%= link_to 'Remove', community_admin_friend_activity_path(current_community.slug, friend, activity), method: :delete, remote: true, style: 'color: #b30000 !important; font-style: italic;' %>
+      <%= link_to 'Remove', community_admin_friend_activity_path(current_community.slug, friend, activity), method: :delete, :data => {:confirm => 'Are you sure you want to remove this activity?'}, remote: true, style: 'color: #b30000 !important; font-style: italic;' %>
     </strong>
   </div>
   <div class='col-md-3'>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -61,8 +61,8 @@
       <% @friends.each do |friend| %>
         <tr id="friend-<%=friend.id%>" style="color: <%= friend.detained? ? "red" : "black" %>;"}>
           <td><%= friend.id %></td>
-          <td><%= friend.first_name %></td>
-          <td><%= friend.last_name %></td>
+          <td><%= link_to friend.first_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
+          <td><%= link_to friend.last_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
           <td><%= friend.a_number %></td>
           <td><%= friend.phone %></td>
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>

--- a/spec/features/community_admin/viewing_accompaniments_calendar_spec.rb
+++ b/spec/features/community_admin/viewing_accompaniments_calendar_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Community Admin viewing the accompaniments calendar', type: :feature do
+  let(:community_admin) { create :user, :community_admin, community: community }
+  let(:community) { create :community, :primary }
+  let(:region) { community.region }
+  let(:team_leader) { create(:user, :accompaniment_leader, community: community) }
+  let!(:activity) { create(:activity, occur_at: 1.hour.from_now, region: region, confirmed: true) }
+  let!(:accompaniment) { create(:accompaniment, user: team_leader, activity: activity) }
+
+  before do
+    login_as(community_admin)
+  end
+
+  describe 'viewing the accompaniments calendar' do
+    before(:each) do
+      visit accompaniments_community_admin_activities_path(community.slug)
+    end
+
+    it 'displays the activity event' do
+      expect(page).to have_content(activity.event.humanize)
+    end
+
+    it 'displays the activity friend name' do
+      expect(page).to have_content(activity.friend.name)
+    end
+
+    it 'displays the number of volunteers' do
+      expect(page).to have_content(activity.volunteer_accompaniments.count)
+    end
+  end
+end


### PR DESCRIPTION
@acatxnamedvirtue I changed the spec to use community_admin rather than regional_admin because community_admin is the lowest authorization level that can access this functionality.  There are some other changes (all things that have been merged into master)....unfortunately I was having trouble excluding them from this PR with the way I was pulling down your forked branch locally.

If you could just take a look at the moved/updated spec and merge into your branch, that would be awesome!